### PR TITLE
Fixes types & readme examples - fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,20 @@ $ yarn add react-native-auto-grow-textinput
 
 After, you can use it in your project:
 
-```javascript
-import { AutoGrowInputText } from 'react-native-auto-grow-textinput';
+```jsx
+import { AutoGrowTextInput } from 'react-native-auto-grow-textinput';
 
 ...
 // If you don't need max height
-<AutoGrowInputText placeholder='Some text here' />
+<AutoGrowTextInput placeholder='Some text here'/>
+
 // else if you need to set up max height
-<AutoGrowInputText placeholder='Some text here' maxHeight={ 120 } />
+<AutoGrowTextInput placeholder='Some text here' maxHeight={ 120 } />
+
+// Connected to state
+<AutoGrowTextInput value={this.state.text} onChangeText={this.onChangeText} />
 ...
-// Also you can use any other TextInput props with AutoGrowInputText component
+// Also you can use any other TextInput props with AutoGrowTextInput component
 ```
 
 I hope it'll save your time.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "@jeremistadler/react-native-auto-grow-textinput",
-  "version": "1.3.0",
+  "name": "react-native-auto-grow-textinput",
+  "version": "1.2.0",
   "description": "This component allows to create auto grow text input for both platforms (iOS and Android).",
   "main": "index.js",
   "types": "src/index.d.ts",
-  "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/jeremistadler/react-native-auto-grow-textinput.git"
+    "url": "https://github.com/rusfearuth/react-native-auto-grow-textinput.git"
   },
   "author": {
     "name": "Alexander Ustinov",
@@ -15,7 +14,7 @@
     "url": "https://github.com/rusfearuth"
   },
   "license": "Apache 2.0",
-  "homepage": "https://github.com/jeremistadler/react-native-auto-grow-textinput",
+  "homepage": "https://github.com/rusfearuth/react-native-auto-grow-textinput",
   "keywords": [
     "textinput",
     "autogrowing",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "react-native-auto-grow-textinput",
-  "version": "1.2.0",
+  "name": "@jeremistadler/react-native-auto-grow-textinput",
+  "version": "1.3.0",
   "description": "This component allows to create auto grow text input for both platforms (iOS and Android).",
   "main": "index.js",
   "types": "src/index.d.ts",
+  "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/rusfearuth/react-native-auto-grow-textinput.git"
+    "url": "https://github.com/jeremistadler/react-native-auto-grow-textinput.git"
   },
   "author": {
     "name": "Alexander Ustinov",
@@ -14,7 +15,7 @@
     "url": "https://github.com/rusfearuth"
   },
   "license": "Apache 2.0",
-  "homepage": "https://github.com/rusfearuth/react-native-auto-grow-textinput",
+  "homepage": "https://github.com/jeremistadler/react-native-auto-grow-textinput",
   "keywords": [
     "textinput",
     "autogrowing",

--- a/src/index.js
+++ b/src/index.js
@@ -80,12 +80,12 @@ export default class AutoGrowTextInput extends React.Component {
     this.setState({ height });
     this.props.onResized && this.props.onResized();
   }
-  
+
   _calcHeight(actualHeight: number, limit:? number) {
     return limit
       ? Math.min(limit, actualHeight)
       : Math.max(this._minHeight(), actualHeight);
   }
-  
+
   _minHeight = () => this.props.minHeight || 30;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -80,12 +80,12 @@ export default class AutoGrowTextInput extends React.Component {
     this.setState({ height });
     this.props.onResized && this.props.onResized();
   }
-
+  
   _calcHeight(actualHeight: number, limit:? number) {
     return limit
       ? Math.min(limit, actualHeight)
       : Math.max(this._minHeight(), actualHeight);
   }
-
+  
   _minHeight = () => this.props.minHeight || 30;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,13 @@ const omit = (obj, keys) => Object.keys(obj)
   .filter((key) => keys.indexOf(key) < 0)
   .reduce((newObj, key) => Object.assign(newObj, { [key]: obj[key] }), {})
 
+type _Style = {[key: string]: Object}
+export type Style = _Style | Array<_Style>;
+
 type Props = {
   maxHeight?: number;
   minHeight?: number;
-  style: View.propTypes.style;
+  style?: Style;
   onResized?: () => void;
   value: ?string;
   shrinkIfEmpty?: boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const omit = (obj, keys) => Object.keys(obj)
   .filter((key) => keys.indexOf(key) < 0)
   .reduce((newObj, key) => Object.assign(newObj, { [key]: obj[key] }), {})
 
-type _Style = {[key: string]: Object}
+type _Style = {[key: string]: Object} | number;
 export type Style = _Style | Array<_Style>;
 
 type Props = {


### PR DESCRIPTION
View.propTypes.style does not exist anymore so used custom style type from here https://github.com/flowtype/flow-typed/issues/631

value prop is required so added small example using value prop